### PR TITLE
Fix updating valhalla.json after changes in valhalla configuration

### DIFF
--- a/scripts/configure_valhalla.sh
+++ b/scripts/configure_valhalla.sh
@@ -124,7 +124,7 @@ if test -f "${CONFIG_FILE}"; then
     valhalla_build_config > ${TMP_CONFIG_FILE}  || exit 1
 
     # for each path in the temp config (excluding array indices)
-    jq -r 'paths | select(map(type) | index("number") | not ) | "." + join(".")' ${TMP_CONFIG_FILE} | while read key ; do
+    jq -r 'paths(scalars | true) | select(map(type) | index("number") | not ) | [.[] | "[\"\(.)\"]"] | join("")' ${TMP_CONFIG_FILE} | while read key ; do
 
       # if the key path does not exist in the existing config 
       jq -e "${key} | if type == \"null\" then false else true end" ${CONFIG_FILE} >/dev/null


### PR DESCRIPTION
After changes done in valhalla/valhalla#5010, the `scripts/configure_valhalla.json` cannot update `valhalla.json` anymore:

```
jq: error: syntax error, unexpected LITERAL, expecting end of file (Unix shell quoting issues?) at <top-level>, line 1:
.thor.costmatrix.hierarchy_limits.max_up_transitions.1 | if type == "null" then false else true end                                                    
```

The reason is that when retrieving value of a key using jq, where a component of the key is a number in string:

```json
"bidirectional_astar": {
    "hierarchy_limits": {
        "max_up_transitions": {
            "1": 400,
            "2": 100,
        },
        "expand_within_distance": {"0": 1e8, "1": 20000, "2": 5000},
    }
}
```

The issue is in the loop, which retrieves all keys from `valhalla.json`:

https://github.com/nilsnolde/docker-valhalla/blob/78e925913b97e401f81608fa24f13ab91924e880/scripts/configure_valhalla.sh#L127-L135

I was able to fix the expression by transforming the keys into [**object index syntax**](https://jqlang.github.io/jq/manual/#optional-object-identifier-index) (instead of the [*object identifier-index* syntax](https://jqlang.github.io/jq/manual/#object-identifier-index)), it should look like this:
```jq
paths(scalars | true) | select(map(type) | index("number") | not ) | [.[] | ".[\"\(.)\"]"] | join("")
```

The generated keys now look like this:
```jq
.["thor"].["bidirectional_astar"].["hierarchy_limits"].["expand_within_distance"].["0"]
.["thor"].["bidirectional_astar"].["hierarchy_limits"].["expand_within_distance"].["1"]
.["thor"].["bidirectional_astar"].["hierarchy_limits"].["expand_within_distance"].["2"]
.["thor"].["bidirectional_astar"].["hierarchy_limits"].["max_up_transitions"].["1"]
.["thor"].["bidirectional_astar"].["hierarchy_limits"].["max_up_transitions"].["2"]
```

With these, jq is now able to retrieve the values correctly:
```
100000000.0
20000
5000
400
100
```
