### PR TITLE
fix json merge of config

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -u
 
 valhalla_image=$1
@@ -123,7 +124,7 @@ if [[ $? -eq 1 ]]; then
 fi
 
 line_count=$(diff -y --suppress-common-lines <(jq --sort-keys . "${custom_file_folder}/valhalla_base.json") <(jq --sort-keys . "${custom_file_folder}/valhalla.json") | wc -l)
-if [[ $line_count != "0" ]]; then
+if [[ $line_count -ne 0 ]]; then
   echo "Valhalla config was not updated correctly. Check the generated config files."
   exit 1
 fi
@@ -144,7 +145,7 @@ if [[ $? -eq 0 ]]; then
 fi
 
 line_count=$(diff -y --suppress-common-lines <(jq --sort-keys . "${custom_file_folder}/valhalla_base.json") <(jq --sort-keys . "${custom_file_folder}/valhalla.json") | wc -l)
-if [[ $line_count != "1" ]]; then
+if [[ $line_count -ne 1 ]]; then
   echo "valhalla.json should not have been updated but was"
   exit 1
 fi


### PR DESCRIPTION
Fixes https://github.com/nilsnolde/docker-valhalla/issues/184

I must confess I used ChatGPT to develop the code for merging the default config with the user overrides but I tested it with a reduced example:

default:
```json
{
	"a": 1,
	"b": 3,
	"c": [
		4,
		5
	],
	"d": {
		"e": 8,
		"f": 9
	},
	"g": {
		"h": 11
	}
}
```
override:
```json
{
	"a": 6,
	"c": [
		7
	],
	"d": {
		"e": 10
	}
}
```
result:
```json
{
	"a": 6,
	"b": 3,
	"c": [
		7
	],
	"d": {
		"e": 10,
		"f": 9
	},
	"g": {
		"h": 11
	}
}
```