### PR TITLE
fix: docker image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A hyper-flexible Docker image for the excellent [Valhalla](https://github.com/va
 # download a file to custom_files and start valhalla
 mkdir custom_files
 wget -O custom_files/andorra-latest.osm.pbf https://download.geofabrik.de/europe/andorra-latest.osm.pbf
-docker run -dt --name valhalla_gis-ops -p 8002:8002 -v $PWD/custom_files:/custom_files ghcr.io/nilsnolde/docker-valhalla:latest
+docker run -dt --name valhalla_gis-ops -p 8002:8002 -v $PWD/custom_files:/custom_files ghcr.io/nilsnolde/docker-valhalla/valhalla:latest
 
 # or let the container download the file for you
-docker run -dt --name valhalla_gis-ops -p 8002:8002 -v $PWD/custom_files:/custom_files -e tile_urls=https://download.geofabrik.de/europe/andorra-latest.osm.pbf ghcr.io/nilsnolde/docker-valhalla:latest
+docker run -dt --name valhalla_gis-ops -p 8002:8002 -v $PWD/custom_files:/custom_files -e tile_urls=https://download.geofabrik.de/europe/andorra-latest.osm.pbf ghcr.io/nilsnolde/docker-valhalla/valhalla:latest
 ```
 
 This image aims at being user-friendly and most efficient with your time and resources. Once built, you can easily change Valhalla's configuration, the underlying OSM data graphs are built from, accompanying data (like Admin Areas, elevation tiles) or even pre-built graph tiles. Upon `docker restart <container>` those changes are taken into account via **hashed files**, and, if necessary, new graph tiles will be built automatically.
@@ -48,7 +48,7 @@ If you want to build the image yourself, be aware that you might need to adapt t
 Then it's a simple
 
 ```shell script
-docker build -t ghcr.io/nilsnolde/docker-valhalla:latest .
+docker build -t ghcr.io/nilsnolde/docker-valhalla/valhalla:latest .
 ```
 
 ## Environment variables
@@ -81,7 +81,7 @@ For the following instructions to work, you'll need to have the image locally av
 Start a background container from that image:
 
 ```bash
-docker run -dt -v $PWD/custom_files:/custom_files -p 8002:8002 --name valhalla ghcr.io/nilsnolde/docker-valhalla:latest
+docker run -dt -v $PWD/custom_files:/custom_files -p 8002:8002 --name valhalla ghcr.io/nilsnolde/docker-valhalla/valhalla:latest
 ```
 
 The important part here is, that you map a volume from your host machine to the container's **`/custom_files`**. The container will dump all relevant Valhalla files to that directory.


### PR DESCRIPTION
It seems like the docker image path is `ghcr.io/nilsnolde/docker-valhalla/valhalla` instead of ghcr.io/nilsnolde/docker-valhalla` 

ref: [https://github.com/nilsnolde/docker-valhalla/pkgs/container/docker-valhalla%2Fvalhalla](https://github.com/nilsnolde/docker-valhalla/pkgs/container/docker-valhalla%2Fvalhalla)