### PR TITLE
Fix configure

### DIFF
--- a/scripts/configure_valhalla.sh
+++ b/scripts/configure_valhalla.sh
@@ -242,7 +242,7 @@ if [[ $use_default_speeds_config == "True" ]]; then
   jq --arg d "${DEFAULT_SPEEDS_CONFIG}" '.mjolnir.default_speeds_config = $d' "${CONFIG_FILE}" | sponge "${CONFIG_FILE}"
 fi
 
-if [[ "${do_build}" == "True" ]] || [[ updated_default_speed_config == "True" ]]; then
+if [[ "${do_build}" == "True" ]] || [[ $updated_default_speed_config == "True" ]]; then
   echo ""
   echo "==============================="
   echo "= Enhancing the initial graph ="

--- a/scripts/configure_valhalla.sh
+++ b/scripts/configure_valhalla.sh
@@ -124,7 +124,7 @@ if test -f "${CONFIG_FILE}"; then
     valhalla_build_config > ${TMP_CONFIG_FILE}  || exit 1
 
     # for each path in the temp config (excluding array indices)
-    jq -r 'paths | select(map(type) | index("number") | not ) | "." + join(".")' ${TMP_CONFIG_FILE} | while read key ; do
+    jq -r 'paths | select(map(type) | index("number") | not ) | ".\"" + join("\".\"") + "\""' ${TMP_CONFIG_FILE} | while read key ; do
 
       # if the key path does not exist in the existing config 
       jq -e "${key} | if type == \"null\" then false else true end" ${CONFIG_FILE} >/dev/null


### PR DESCRIPTION
This fixes two bugs in the configure_valhalla.sh script.

- The newer hierarchy_limits object contains integer object keys and jq expects these to be quoted.
- The updated_default_speed_config variable was missing the $ sign which means the check always failed

I can really recommend [shellcheck](https://www.shellcheck.net) or [shellcheck extension](https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck) to catch stuff like the second error.